### PR TITLE
Fixed a strict standards notice in the shopping cart

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,4 +1,5 @@
 Payment 1.0.2, Sep 12, 2015
 ====================================
 
+- fixed a strict standards notice in the shopping cart
 - added a license info into each file;

--- a/module/Payment/src/Payment/View/Helper/PaymentShoppingCart.php
+++ b/module/Payment/src/Payment/View/Helper/PaymentShoppingCart.php
@@ -46,7 +46,8 @@ class PaymentShoppingCart extends AbstractHelper
      */
     public function __construct()
     {
-        array_walk(PaymentService::getActiveShoppingCartItems(), function($item){
+        $items = PaymentService::getActiveShoppingCartItems();
+        array_walk($items, function($item){
             $this->itemsCount  += $item['count'];
         });
 


### PR DESCRIPTION
Related to esase/dream-cms-payment-module#2
